### PR TITLE
[New Feature] Native Discord Rich Presence Support

### DIFF
--- a/bukkit/src/main/java/net/labymod/serverapi/bukkit/LabyModPlugin.java
+++ b/bukkit/src/main/java/net/labymod/serverapi/bukkit/LabyModPlugin.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.Getter;
+import lombok.NonNull;
 import net.labymod.serverapi.Addon;
 import net.labymod.serverapi.LabyModAPI;
 import net.labymod.serverapi.LabyModConfig;
@@ -17,6 +18,8 @@ import net.labymod.serverapi.bukkit.event.MessageSendEvent;
 import net.labymod.serverapi.bukkit.event.PermissionsSendEvent;
 import net.labymod.serverapi.bukkit.listener.PlayerJoinListener;
 import net.labymod.serverapi.bukkit.utils.PacketUtils;
+import net.labymod.serverapi.discord.RichPresence;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -188,6 +191,16 @@ public class LabyModPlugin extends JavaPlugin {
         // Sending the packet
         if ( !sendEvent.isCancelled() )
             packetUtils.sendPacket( player, packetUtils.getPluginMessagePacket( "LMC", api.getBytesToSend( messageKey, messageContents.toString() ) ) );
+    }
+    
+    /**
+     * Sends the Discord Rich Presence message to the player
+     * 
+     * @param player		the player the rich presence should be sent to
+     * @param richPresence	the presence object
+     */
+    public void sendRichPresence ( @NonNull Player player, @NonNull RichPresence richPresence ) {
+    	sendServerMessage(player, "discord_rpc", richPresence.toJson());
     }
 
     /**

--- a/bukkit/src/main/java/net/labymod/serverapi/bukkit/LabyModPlugin.java
+++ b/bukkit/src/main/java/net/labymod/serverapi/bukkit/LabyModPlugin.java
@@ -29,6 +29,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
 
 /**
  * Class created by qlow | Jan
@@ -199,8 +201,19 @@ public class LabyModPlugin extends JavaPlugin {
      * @param player		the player the rich presence should be sent to
      * @param richPresence	the presence object
      */
-    public void sendRichPresence ( @NonNull Player player, @NonNull RichPresence richPresence ) {
+    public void sendRichPresence ( @NonNull final Player player, @NonNull RichPresence richPresence ) {
     	sendServerMessage(player, "discord_rpc", richPresence.toJson());
+    	
+    	richPresence.addObserver(new Observer() {
+			@Override
+			public void update(Observable observable, Object object) {
+				if(player.isOnline()) {
+					observable.deleteObserver(this);
+				}
+				
+				sendServerMessage(player, "discord_rpc", ((RichPresence) observable).toJson());
+			}
+		});
     }
 
     /**

--- a/bungeecord/src/main/java/net/labymod/serverapi/bungee/LabyModPlugin.java
+++ b/bungeecord/src/main/java/net/labymod/serverapi/bungee/LabyModPlugin.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import lombok.Getter;
+import lombok.NonNull;
 import net.labymod.serverapi.LabyModAPI;
 import net.labymod.serverapi.LabyModConfig;
 import net.labymod.serverapi.Permission;
@@ -19,6 +20,8 @@ import net.md_5.bungee.protocol.packet.PluginMessage;
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Observable;
+import java.util.Observer;
 
 /**
  * Class created by qlow | Jan
@@ -94,8 +97,18 @@ public class LabyModPlugin extends Plugin {
      * @param player		the player the rich presence should be sent to
      * @param richPresence	the presence object
      */
-    public void sendRichPresence (ProxiedPlayer player, RichPresence richPresence ) {
+    public void sendRichPresence (@NonNull final ProxiedPlayer player, RichPresence richPresence ) {
     	sendServerMessage(player, "discord_rpc", richPresence.toJson());
+    	
+    	richPresence.addObserver(new Observer() {
+			@Override
+			public void update(Observable observable, Object object) {
+				if(player.isConnected()) {
+					observable.deleteObserver(this);
+				}
+				
+				sendServerMessage(player, "discord_rpc", ((RichPresence) observable).toJson());
+			}});
     }
 
     /**

--- a/bungeecord/src/main/java/net/labymod/serverapi/bungee/LabyModPlugin.java
+++ b/bungeecord/src/main/java/net/labymod/serverapi/bungee/LabyModPlugin.java
@@ -11,6 +11,7 @@ import net.labymod.serverapi.bungee.event.MessageSendEvent;
 import net.labymod.serverapi.bungee.event.PermissionsSendEvent;
 import net.labymod.serverapi.bungee.listener.PlayerJoinListener;
 import net.labymod.serverapi.bungee.listener.PluginMessageListener;
+import net.labymod.serverapi.discord.RichPresence;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.protocol.packet.PluginMessage;
@@ -85,6 +86,16 @@ public class LabyModPlugin extends Plugin {
         // Sending the packet
         if ( !sendEvent.isCancelled() )
             player.unsafe().sendPacket( new PluginMessage( "LMC", api.getBytesToSend( messageKey, messageContents.toString() ), false ) );
+    }
+    
+    /**
+     * Sends the Discord Rich Presence message to the player
+     * 
+     * @param player		the player the rich presence should be sent to
+     * @param richPresence	the presence object
+     */
+    public void sendRichPresence (ProxiedPlayer player, RichPresence richPresence ) {
+    	sendServerMessage(player, "discord_rpc", richPresence.toJson());
     }
 
     /**

--- a/common/src/main/java/net/labymod/serverapi/discord/Game.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Game.java
@@ -6,15 +6,32 @@ import java.util.Observable;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
-import lombok.Setter;
 
 @Builder
 @Getter
-@Setter
 public class Game extends Observable
 {
 	@NonNull
 	private String gameMode;
 	private Instant startTime;
 	private Instant endTime;
+	
+	public void setGameMode(String gameMode)
+	{
+		this.gameMode = gameMode;
+		setChanged();
+		notifyObservers();
+	}
+	public void setStartTime(Instant startTime)
+	{
+		this.startTime = startTime;
+		setChanged();
+		notifyObservers();
+	}
+	public void setEndTime(Instant endTime)
+	{
+		this.endTime = endTime;
+		setChanged();
+		notifyObservers();
+	}
 }

--- a/common/src/main/java/net/labymod/serverapi/discord/Game.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Game.java
@@ -1,0 +1,20 @@
+package net.labymod.serverapi.discord;
+
+import java.time.Instant;
+import java.util.Observable;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class Game extends Observable
+{
+	@NonNull
+	private String gameMode;
+	private Instant startTime;
+	private Instant endTime;
+}

--- a/common/src/main/java/net/labymod/serverapi/discord/Game.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Game.java
@@ -9,27 +9,25 @@ import lombok.NonNull;
 
 @Builder
 @Getter
-public class Game extends Observable
-{
+public class Game extends Observable {
 	@NonNull
 	private String gameMode;
 	private Instant startTime;
 	private Instant endTime;
 	
-	public void setGameMode(String gameMode)
-	{
+	public void setGameMode(String gameMode) {
 		this.gameMode = gameMode;
 		setChanged();
 		notifyObservers();
 	}
-	public void setStartTime(Instant startTime)
-	{
+	
+	public void setStartTime(Instant startTime) {
 		this.startTime = startTime;
 		setChanged();
 		notifyObservers();
 	}
-	public void setEndTime(Instant endTime)
-	{
+	
+	public void setEndTime(Instant endTime) {
 		this.endTime = endTime;
 		setChanged();
 		notifyObservers();

--- a/common/src/main/java/net/labymod/serverapi/discord/Party.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Party.java
@@ -19,17 +19,20 @@ public class Party extends Observable
 	{
 		this.partyId = partyId;
 		setChanged();
+		notifyObservers();
 	}
 
 	public void setPartySize(int partySize)
 	{
 		this.partySize = partySize;
 		setChanged();
+		notifyObservers();
 	}
 
 	public void setPartyMax(int partyMax)
 	{
 		this.partyMax = partyMax;
 		setChanged();
+		notifyObservers();
 	}
 }

--- a/common/src/main/java/net/labymod/serverapi/discord/Party.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Party.java
@@ -8,29 +8,25 @@ import lombok.NonNull;
 
 @Builder
 @Getter
-public class Party extends Observable
-{
+public class Party extends Observable {
 	@NonNull
 	private String partyId;
 	private int partySize;
 	private int partyMax;
 	
-	public void setPartyId(String partyId)
-	{
+	public void setPartyId(String partyId) {
 		this.partyId = partyId;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setPartySize(int partySize)
-	{
+	public void setPartySize(int partySize) {
 		this.partySize = partySize;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setPartyMax(int partyMax)
-	{
+	public void setPartyMax(int partyMax) {
 		this.partyMax = partyMax;
 		setChanged();
 		notifyObservers();

--- a/common/src/main/java/net/labymod/serverapi/discord/Party.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/Party.java
@@ -1,0 +1,35 @@
+package net.labymod.serverapi.discord;
+
+import java.util.Observable;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+
+@Builder
+@Getter
+public class Party extends Observable
+{
+	@NonNull
+	private String partyId;
+	private int partySize;
+	private int partyMax;
+	
+	public void setPartyId(String partyId)
+	{
+		this.partyId = partyId;
+		setChanged();
+	}
+
+	public void setPartySize(int partySize)
+	{
+		this.partySize = partySize;
+		setChanged();
+	}
+
+	public void setPartyMax(int partyMax)
+	{
+		this.partyMax = partyMax;
+		setChanged();
+	}
+}

--- a/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
@@ -22,30 +22,35 @@ public class RichPresence extends Observable implements Observer
 	{
 		this.matchSecret = matchSecret;
 		setChanged();
+		notifyObservers();
 	}
 
 	public void setSpecrateSecret(String specrateSecret)
 	{
 		this.spectateSecret = specrateSecret;
 		setChanged();
+		notifyObservers();
 	}
 
 	public void setJoinSecrert(String joinSecrert)
 	{
 		this.joinSecrert = joinSecrert;
 		setChanged();
+		notifyObservers();
 	}
 
 	public void setParty(Party party)
 	{
 		this.party = party;
 		setChanged();
+		notifyObservers();
 	}
 	
 	@Override
 	public void update(Observable o, Object arg)
 	{
 		setChanged();
+		notifyObservers();
 	}
 	
 	public JsonObject toJson()

--- a/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
@@ -1,0 +1,104 @@
+package net.labymod.serverapi.discord;
+
+import java.util.Observable;
+import java.util.Observer;
+
+import com.google.gson.JsonObject;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class RichPresence extends Observable implements Observer
+{
+	private String matchSecret;
+	private String spectateSecret;
+	private String joinSecrert;
+	private Game game;
+	private Party party;
+	
+	public void setMatchSecret(String matchSecret)
+	{
+		this.matchSecret = matchSecret;
+		setChanged();
+	}
+
+	public void setSpecrateSecret(String specrateSecret)
+	{
+		this.spectateSecret = specrateSecret;
+		setChanged();
+	}
+
+	public void setJoinSecrert(String joinSecrert)
+	{
+		this.joinSecrert = joinSecrert;
+		setChanged();
+	}
+
+	public void setParty(Party party)
+	{
+		this.party = party;
+		setChanged();
+	}
+	
+	@Override
+	public void update(Observable o, Object arg)
+	{
+		setChanged();
+	}
+	
+	public JsonObject toJson()
+	{
+		JsonObject object = new JsonObject();
+		
+		addSecretsToJson(object);
+		addGameToJson(object);
+		addPartyToJson(object);
+		
+		return object;
+	}
+	
+	private void addSecretsToJson(JsonObject object)
+	{
+		object.addProperty("hasMatchSecret", matchSecret != null);
+		if(matchSecret != null)
+		{
+			object.addProperty("matchSecret", matchSecret);
+		}
+		
+		object.addProperty("hasSpectateSecret", spectateSecret != null);
+		if(spectateSecret != null)
+		{
+			object.addProperty("spectateSecret", spectateSecret);
+		}
+		
+		object.addProperty("hasJoinSecret", joinSecrert != null);
+		if(spectateSecret != null)
+		{
+			object.addProperty("joinSecret", joinSecrert);
+		}
+	}
+	
+	private void addGameToJson(JsonObject object)
+	{
+		object.addProperty("hasGame", game != null);
+		if(game != null)
+		{
+			object.addProperty("game_mode", game.getGameMode());
+			object.addProperty("game_startTime", game.getStartTime() != null ? game.getStartTime().toEpochMilli() : 0);
+			object.addProperty("game_endTime", game.getEndTime() != null ? game.getEndTime().toEpochMilli() : 0);
+		}
+	}
+	
+	private void addPartyToJson(JsonObject object)
+	{
+		object.addProperty("hasParty", party != null);
+		if(party != null)
+		{
+			object.addProperty("partyId", party.getPartyId());
+			object.addProperty("party_size", party.getPartySize());
+			object.addProperty("party_max", party.getPartyMax());
+		}
+	}
+}

--- a/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
@@ -1,5 +1,7 @@
 package net.labymod.serverapi.discord;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Observable;
 import java.util.Observer;
 
@@ -10,66 +12,68 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class RichPresence extends Observable implements Observer
-{
+public class RichPresence extends Observable implements Observer, Closeable {
 	private String matchSecret;
 	private String spectateSecret;
 	private String joinSecrert;
 	private Game game;
 	private Party party;
 	
-	public void setMatchSecret(String matchSecret)
-	{
+	public void setMatchSecret(String matchSecret) {
 		this.matchSecret = matchSecret;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setSpectateSecret(String spectateSecret)
-	{
+	public void setSpectateSecret(String spectateSecret) {
 		this.spectateSecret = spectateSecret;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setJoinSecrert(String joinSecret)
-	{
+	public void setJoinSecrert(String joinSecret) {
 		this.joinSecrert = joinSecret;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setParty(Party party)
-	{
+	public void setParty(Party party) {
+		if(this.party != null) {
+			this.party.deleteObserver(this);
+		}
+		
 		this.party = party;
 		
-		if(party != null)
+		if(party != null) {
 			party.addObserver(this);
+		}
 		
 		setChanged();
 		notifyObservers();
 	}
 	
-	public void setGame(Game game)
-	{
+	public void setGame(Game game) {
+		if(this.game != null) {
+			this.game.deleteObserver(this);
+		}
+		
 		this.game = game;
 		
-		if(game != null)
+		if(game != null) {
 			game.addObserver(this);
+		}	
 		
 		setChanged();
 		notifyObservers();
 	}
 	
 	@Override
-	public void update(Observable o, Object arg)
-	{
+	public void update(Observable o, Object arg) {
 		setChanged();
 		notifyObservers();
 	}
 	
-	public JsonObject toJson()
-	{
+	public JsonObject toJson() {
 		JsonObject object = new JsonObject();
 		
 		addSecretsToJson(object);
@@ -79,46 +83,49 @@ public class RichPresence extends Observable implements Observer
 		return object;
 	}
 	
-	private void addSecretsToJson(JsonObject object)
-	{
+	private void addSecretsToJson(JsonObject object) {
 		object.addProperty("hasMatchSecret", matchSecret != null);
-		if(matchSecret != null)
-		{
+		if(matchSecret != null) {
 			object.addProperty("matchSecret", matchSecret);
 		}
 		
 		object.addProperty("hasSpectateSecret", spectateSecret != null);
-		if(spectateSecret != null)
-		{
+		if(spectateSecret != null) {
 			object.addProperty("spectateSecret", spectateSecret);
 		}
 		
 		object.addProperty("hasJoinSecret", joinSecrert != null);
-		if(spectateSecret != null)
-		{
+		if(spectateSecret != null) {
 			object.addProperty("joinSecret", joinSecrert);
 		}
 	}
 	
-	private void addGameToJson(JsonObject object)
-	{
+	private void addGameToJson(JsonObject object) {
 		object.addProperty("hasGame", game != null);
-		if(game != null)
-		{
+		if(game != null) {
 			object.addProperty("game_mode", game.getGameMode());
 			object.addProperty("game_startTime", game.getStartTime() != null ? game.getStartTime().toEpochMilli() : 0);
 			object.addProperty("game_endTime", game.getEndTime() != null ? game.getEndTime().toEpochMilli() : 0);
 		}
 	}
 	
-	private void addPartyToJson(JsonObject object)
-	{
+	private void addPartyToJson(JsonObject object) {
 		object.addProperty("hasParty", party != null);
-		if(party != null)
-		{
+		if(party != null) {
 			object.addProperty("partyId", party.getPartyId());
 			object.addProperty("party_size", party.getPartySize());
 			object.addProperty("party_max", party.getPartyMax());
 		}
+	}
+	
+	public void destroy() {
+		deleteObservers();
+		setGame(null);
+		setParty(null);
+	}
+
+	@Override
+	public void close() throws IOException {
+		destroy();
 	}
 }

--- a/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
+++ b/common/src/main/java/net/labymod/serverapi/discord/RichPresence.java
@@ -25,16 +25,16 @@ public class RichPresence extends Observable implements Observer
 		notifyObservers();
 	}
 
-	public void setSpecrateSecret(String specrateSecret)
+	public void setSpectateSecret(String spectateSecret)
 	{
-		this.spectateSecret = specrateSecret;
+		this.spectateSecret = spectateSecret;
 		setChanged();
 		notifyObservers();
 	}
 
-	public void setJoinSecrert(String joinSecrert)
+	public void setJoinSecrert(String joinSecret)
 	{
-		this.joinSecrert = joinSecrert;
+		this.joinSecrert = joinSecret;
 		setChanged();
 		notifyObservers();
 	}
@@ -42,6 +42,21 @@ public class RichPresence extends Observable implements Observer
 	public void setParty(Party party)
 	{
 		this.party = party;
+		
+		if(party != null)
+			party.addObserver(this);
+		
+		setChanged();
+		notifyObservers();
+	}
+	
+	public void setGame(Game game)
+	{
+		this.game = game;
+		
+		if(game != null)
+			game.addObserver(this);
+		
 		setChanged();
 		notifyObservers();
 	}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | -   <!-- #-prefixed issue number(s), if any -->

Currently Discord Rich Presence support is only through sending a json object directly.
This commit adds classes for Rich Presence, Game, Party and a method for sending in the bukkit and bungeecord implementation.

Every model extends the Observable pattern.
You can attach Observers, which will get called, when a value changes.

Automatic updates are implemented not due to a missing general player object.
