### PR TITLE
Removed non-functional icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # LabyMod Server API
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/LabyMod/labymod-server-api/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/LabyMod/labymod-server-api/?branch=master)
 [![Discord](https://img.shields.io/discord/412724944112320513.svg)](https://labymod.net/dc/dev)
-[![CLA assistant](https://cla-assistant.io/readme/badge/LabyMod/labymod-server-api)](https://cla-assistant.io/LabyMod/labymod-server-api)
 
 Our new Server API allows you to communicate between the LabyMod client and the server by using simple JSON messages. It also allows you to enable or disable LabyMod features. 
 If you want to find out how our API works, visit https://docs.labymod.net/pages/server/introduction/


### PR DESCRIPTION
There is no CLA to sign for LabyMod/labymod-server-api.
So this symbol is useless.

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

I have removed an unnecessary icon from the README as it has no function. It is about the CLA icon, which is useless because it just shows an error.