### PR TITLE
Fix bungeecord version.

### DIFF
--- a/proxy/bungeecord/src/main/java/net/labymod/serverapi/bungee/BungeeLabyModPlugin.java
+++ b/proxy/bungeecord/src/main/java/net/labymod/serverapi/bungee/BungeeLabyModPlugin.java
@@ -24,6 +24,7 @@ public class BungeeLabyModPlugin extends Plugin {
     PluginManager pluginManager = this.getProxy().getPluginManager();
 
     pluginManager.registerListener(this, (Listener) this.service.getConnectionService());
+    pluginManager.registerListener(this, (Listener) this.service.getPayloadCommunicator());
     pluginManager.registerListener(this, new BungeeLegacyLabyModPayloadChannel(this.service, this));
   }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | #9

One of the listeners wasn't registered which is why the plugin doesn't work on bungeecord as mentioned in #9. I'm gonna move the saturation thing to a seperate ticket.
